### PR TITLE
Fix SceneBrowser/Properties modal size regression with recent DankModal changes

### DIFF
--- a/SceneBrowserModal.qml
+++ b/SceneBrowserModal.qml
@@ -18,8 +18,12 @@ DankModal {
 
     signal sceneSelected(string sceneId)
 
-    width: Math.min(screenWidth - 100, 1200)
-    height: Math.min(screenHeight - 100, 800)
+    // DankMaterialShell uses modalWidth/modalHeight for the actual window size.
+    // Keep width/height in sync for any content that relies on them.
+    modalWidth: Math.min(screenWidth - 100, 1200)
+    modalHeight: Math.min(screenHeight - 100, 800)
+    width: modalWidth
+    height: modalHeight
     positioning: "center"
     allowStacking: true
 

--- a/ScenePropertiesModal.qml
+++ b/ScenePropertiesModal.qml
@@ -17,8 +17,12 @@ DankModal {
 
     signal propertiesSaved(var properties)
 
-    width: Math.min(screenWidth - 100, 700)
-    height: Math.min(screenHeight - 100, 600)
+    // DankMaterialShell uses modalWidth/modalHeight for the actual window size.
+    // Keep width/height in sync for any content that relies on them.
+    modalWidth: Math.min(screenWidth - 100, 700)
+    modalHeight: Math.min(screenHeight - 100, 600)
+    width: modalWidth
+    height: modalHeight
     positioning: "center"
     allowStacking: true
 


### PR DESCRIPTION
Recent changes in DankMaterialShell’s DankModal switched window sizing to use `modalWidth`/`modalHeight` instead of the instance width/height. 

DankModal computes its actual window size from `modalWidth`/`modalHeight` (defaults are _small af_). After the upstream change, width/height no longer controlled the modal window size.
This plugin’s modals were still only setting width/height, so they began opening at the default 400x300, making the Scene Browser effectively unusable.

Do note:
This is a compatibility fix for newer DankMaterialShell versions, while preserving the width/height setting for any older installations that have older code that is still relying on width/height.

fixes #5 