### PR TITLE
feat: add per-output hardware decoder selection

### DIFF
--- a/js/CommandBuilder.js
+++ b/js/CommandBuilder.js
@@ -47,6 +47,12 @@ function buildCommandArgs(o) {
         args.push(String(fps))
     }
 
+    var hwdec = o.settings.hwdec || "auto"
+    if (hwdec === "nvdec-copy" || hwdec === "no") {
+        args.push("--hwdec")
+        args.push(hwdec)
+    }
+
     var scaling = o.settings.scaling || "default"
     if (scaling !== "default") {
         args.push("--scaling")

--- a/ui/RenderSettingsCard.qml
+++ b/ui/RenderSettingsCard.qml
@@ -8,8 +8,29 @@ Column {
     property var getOutputSetting
     property var saveOutputSetting
     property string settingsSceneId: ""
+    readonly property var hwdecOptions: [
+        "Automatic",
+        "NVIDIA NVDEC (copy-back)",
+        "Software decoding"
+    ]
 
     signal configurePropertiesRequested()
+
+    function hwdecDisplay(value) {
+        switch (value) {
+        case "nvdec-copy": return "NVIDIA NVDEC (copy-back)"
+        case "no": return "Software decoding"
+        default: return "Automatic"
+        }
+    }
+
+    function hwdecValue(label) {
+        switch (label) {
+        case "NVIDIA NVDEC (copy-back)": return "nvdec-copy"
+        case "Software decoding": return "no"
+        default: return "auto"
+        }
+    }
 
     width: parent.width
     spacing: Theme.spacingM
@@ -117,6 +138,48 @@ Column {
         }
         StyledText {
             text: "Frame rate for the animated wallpaper"
+            font.pixelSize: Theme.fontSizeSmall * 0.9
+            opacity: 0.5
+            width: parent.width
+            wrapMode: Text.Wrap
+        }
+    }
+
+    Column {
+        width: parent.width
+        spacing: 2
+
+        Row {
+            id: hwdecRow
+            width: parent.width
+            spacing: Theme.spacingM
+
+            StyledText {
+                text: "Hardware Decoder"
+                font.pixelSize: Theme.fontSizeSmall
+                width: 180
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            DankDropdown {
+                id: hwdecDropdown
+                width: parent.width - 180 - Theme.spacingM
+                options: root.hwdecOptions
+                compactMode: true
+
+                Binding {
+                    target: hwdecDropdown
+                    property: "currentValue"
+                    value: root.hwdecDisplay(getOutputSetting("hwdec", "auto"))
+                }
+
+                onValueChanged: (value) => {
+                    saveOutputSetting("hwdec", root.hwdecValue(value))
+                }
+            }
+        }
+        StyledText {
+            text: "Select automatic, NVIDIA copy-back, or software video decoding"
             font.pixelSize: Theme.fontSizeSmall * 0.9
             opacity: 0.5
             width: parent.width


### PR DESCRIPTION
## Summary

- add a per-output video decoder selector with automatic, NVIDIA copy-back, and software-decoding modes
- persist the selected mode alongside the existing output render settings
- pass `--hwdec nvdec-copy` or `--hwdec no` only for explicit selections
- preserve the existing/default behavior by omitting the flag for automatic or unset values
- safely fall back to automatic behavior for an invalid stored value

## Dependency and scope

The explicit modes depend on Almamu/linux-wallpaperengine#670. The PR is intentionally marked as a draft until that CLI option is available upstream. Automatic mode continues to work with older versions because it does not emit the new flag.

This is a focused follow-up to #17. It does not add an explicit VAAPI selector; the available explicit modes match the values currently proposed in the dependency PR.

## Test plan

- [x] unset and `auto` values omit `--hwdec`
- [x] `nvdec-copy` emits `--hwdec nvdec-copy`
- [x] `no` emits `--hwdec no`
- [x] an invalid value safely falls back to automatic behavior
- [x] an existing 144 FPS setting remains in the generated command
- [x] JavaScript syntax and command-builder cases pass
- [x] QML AST parsing passes

Follow-up to #17
